### PR TITLE
Adding disco in list of supported releases

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -5,6 +5,7 @@ description: Basic LDAP install with know test data (see files/)
 tags:
   - misc
 series:
+  - disco
   - bionic
   - xenial
   - trusty


### PR DESCRIPTION
Deployed successfully the charm with disco serie:

ubuntu@camille-rodriguez-bastion:~/charms/charm-ldap-test-fixture$ juju status
Model  Controller                     Cloud/Region             Version  SLA          Timestamp
ldap   camille_rodriguez-serverstack  serverstack/serverstack  2.6.6    unsupported  19:57:15Z
App          Version  Status  Scale  Charm              Store       Rev  OS      Notes
ldap-server           active      1  ldap-test-fixture  jujucharms    3  ubuntu
Unit            Workload  Agent  Machine  Public address  Ports  Message
ldap-server/0*  active    idle   0        10.5.0.16              Unit is ready
Machine  State    DNS        Inst id                               Series  AZ    Message
0        started  10.5.0.16  17e143c4-75ea-4c25-b6e8-24aad0726520  disco   nova  ACTIVE
